### PR TITLE
Support for pulse messages.

### DIFF
--- a/renderc/net.flowmill.render/src/net/flowmill/render/generator/SpanGenerator.xtend
+++ b/renderc/net.flowmill.render/src/net/flowmill/render/generator/SpanGenerator.xtend
@@ -31,6 +31,8 @@ import org.eclipse.emf.ecore.resource.Resource
 import net.flowmill.render.render.FieldTypeEnum
 import java.util.Arrays
 
+import static net.flowmill.render.generator.AppPacker.pulseMessageName
+
 import static extension net.flowmill.render.extensions.AppExtensions.*
 import static extension net.flowmill.render.extensions.FieldExtensions.*
 import static extension net.flowmill.render.extensions.SpanExtensions.*
@@ -387,6 +389,11 @@ class SpanGenerator {
 			 */
 			Index& operator=(const Index&) = delete;
 
+			/**
+			 * Send a heartbeat pulse to all downstream peers
+			 */
+			void send_pulse();
+
 			«FOR remote_app_name : app.remoteApps.map[name].sort»
 				/* Writer for sending proxy span messages to «remote_app_name» app */
 				std::vector<::«pkg_name»::«remote_app_name»::Writer> «remote_app_name»_writers_;
@@ -427,6 +434,15 @@ class SpanGenerator {
 		{
 			«FOR span : app.spans»
 				f("«span.name»", «span.name».size(), «span.name».max_size(), «span.pool_size»);
+			«ENDFOR»
+		}
+
+		void «pkg_name»::«app.name»::Index::send_pulse()
+		{
+			«FOR ran : app.remoteApps.map[name].sort»
+				for (auto &writer : «ran»_writers_) {
+					writer.«pulseMessageName»();
+				}
 			«ENDFOR»
 		}
 

--- a/renderc/net.flowmill.render/src/net/flowmill/render/validation/RenderValidator.xtend
+++ b/renderc/net.flowmill.render/src/net/flowmill/render/validation/RenderValidator.xtend
@@ -25,6 +25,8 @@ import net.flowmill.render.render.RenderPackage
 import net.flowmill.render.render.Message
 import net.flowmill.render.render.MessageType
 import net.flowmill.render.render.RpcIdRange
+import static net.flowmill.render.generator.AppPacker.rpcIdRangeMin
+import static net.flowmill.render.generator.AppPacker.rpcIdRangeMax
 import static extension net.flowmill.render.extensions.MessageExtensions.span
 
 /**
@@ -150,11 +152,6 @@ class RenderValidator extends AbstractRenderValidator {
 
 	@Check
 	def void checkRpcIdRange(RpcIdRange range) {
-		// RPC ID needs to fit in a u16.
-		// Upper half of the range is reserved for future use.
-		val rpcIdRangeMin = 0;
-		val rpcIdRangeMax = 32767;
-
 		if (range.start < rpcIdRangeMin) {
 			error('''Invalid RPC ID range (start < «rpcIdRangeMin»)''',
 				RenderPackage.Literals.RPC_ID_RANGE__START)


### PR DESCRIPTION
Pulse messages are intended for communicating heartbeats to RPC peers, and
are to be handled by the Render framework (not propagated to user code).