### PR TITLE
Fail agent quickly on startup if insufficient permissions to install BPF code or other privileged operations.

### DIFF
--- a/collector/kernel/bpf_handler.cc
+++ b/collector/kernel/bpf_handler.cc
@@ -42,8 +42,9 @@ BPFHandler::BPFHandler(uv_loop_t &loop, std::string full_program,
     full_program = "#define ENABLE_TCP_DATA_STREAM 1\n" + full_program;
   }
   int res = probe_handler_.start_bpf_module(full_program, bpf_module_, perf_);
-  if (res != 0)
-    throw std::runtime_error("ProbeHandler couldn't load BPFModule");
+  if (res != 0) {
+    throw std::system_error(errno, std::generic_category(), "ProbeHandler couldn't load BPFModule");
+  }
 }
 
 BPFHandler::~BPFHandler()

--- a/collector/kernel/kernel_collector.cc
+++ b/collector/kernel/kernel_collector.cc
@@ -278,47 +278,53 @@ void KernelCollector::on_authenticated()
 
 void KernelCollector::probe_holdoff_timeout(uv_timer_t *timer)
 {
+  auto const upstream_connection_flush_and_close = [this] () {
+    upstream_connection_.flush();
+    upstream_connection_.close();
+  };
+
   if (entrypoint_error_ != EntrypointError::none) {
-    print_troubleshooting_message_and_exit(log_, host_info_, entrypoint_error_);
+    print_troubleshooting_message_and_exit(host_info_, entrypoint_error_, log_, upstream_connection_flush_and_close);
+    return;
   }
 
   LOG::trace("Adding probes");
 
   last_probe_monotonic_time_ns_ = monotonic();
 
+  auto const handle_exception = [&, this] (TroubleshootItem item, std::exception const &e) {
+    log_.error("BPFHandler threw exception when initializing BPF or loading probes, closing connection: {}", e.what());
+    print_troubleshooting_message_and_exit(host_info_, item, e, log_, upstream_connection_flush_and_close);
+  };
+
   try {
     bpf_handler_.emplace(loop_, full_program_, enable_http_metrics_, enable_userland_tcp_, bpf_dump_file_, log_, encoder_.get());
     writer_.bpf_compiled();
-  } catch (std::exception &e) {
-    print_troubleshooting_message_and_exit(log_,
-                                           host_info_,
-                                           TroubleshootItem::bpf_compilation_failed,
-                                           e);
-    upstream_connection_.flush();
-    upstream_connection_.close();
-    return;
-  }
 
-  bpf_handler_->load_buffered_poller(upstream_connection_.buffered_writer(),
-                                     boot_time_adjustment_, curl_engine_, nic_poller_,
-                                     cgroup_settings_, cpu_mem_io_settings_);
+    bpf_handler_->load_buffered_poller(upstream_connection_.buffered_writer(),
+                                       boot_time_adjustment_, curl_engine_, nic_poller_,
+                                       cgroup_settings_, cpu_mem_io_settings_);
 
-  try {
     bpf_handler_->load_probes(writer_);
+
+    /* Start running buf_poller in steady-state */
+    writer_.begin_telemetry();
+    writer_.collector_health(integer_value(::collector::CollectorStatus::healthy), 0);
+    LOG::info("Agent connected successfully. Telemetry is flowing!");
+    is_connected_ = true;
+
+    enter_polling_state();
+  } catch (std::system_error &e) {
+    if (e.code().value() == EPERM) {
+      handle_exception(TroubleshootItem::operation_not_permitted, e);
+      return;
+    }
+    handle_exception(TroubleshootItem::bpf_compilation_failed, e);
+    return;
   } catch (std::exception &e) {
-    log_.error("BPFHandler threw exception when loading probes, closing connection: {}", e.what());
-    upstream_connection_.flush();
-    upstream_connection_.close();
+    handle_exception(TroubleshootItem::bpf_compilation_failed, e);
     return;
   }
-
-  /* Start running buf_poller in steady-state */
-  writer_.begin_telemetry();
-  writer_.collector_health(integer_value(::collector::CollectorStatus::healthy), 0);
-  LOG::info("Agent connected successfully. Telemetry is flowing!");
-  is_connected_ = true;
-
-  enter_polling_state();
 }
 
 void KernelCollector::send_connection_metadata()

--- a/collector/kernel/kernel_collector.cc
+++ b/collector/kernel/kernel_collector.cc
@@ -292,7 +292,7 @@ void KernelCollector::probe_holdoff_timeout(uv_timer_t *timer)
 
   last_probe_monotonic_time_ns_ = monotonic();
 
-  auto const handle_exception = [&, this] (TroubleshootItem item, std::exception const &e) {
+  auto const handle_exception = [&] (TroubleshootItem item, std::exception const &e) {
     log_.error("BPFHandler threw exception when initializing BPF or loading probes, closing connection: {}", e.what());
     print_troubleshooting_message_and_exit(host_info_, item, e, log_, upstream_connection_flush_and_close);
   };

--- a/collector/kernel/main.cc
+++ b/collector/kernel/main.cc
@@ -21,6 +21,7 @@
 #include <collector/constants.h>
 #include <collector/kernel/cgroup_handler.h>
 #include <collector/kernel/kernel_collector.h>
+#include <collector/kernel/troubleshooting.h>
 #include <common/cloud_platform.h>
 #include <config/config_file.h>
 #include <platform/platform.h>
@@ -563,111 +564,124 @@ int main(int argc, char *argv[]) {
     configuration_data.labels()["host"] = override_agent_host;
   }
 
-  /* mount debugfs if it is not mounted */
-  mount_debugfs_if_required();
-
-  /* Read our BPF program*/
-  /* resolve includes */
-  std::string bpf_src((char *)agent_bpf_c, agent_bpf_c_len);
-#ifdef CONFIGURABLE_BPF
-  if (bpf_file.Matched()) {
-    bpf_src = *read_file_as_string(bpf_file.Get().c_str()).try_raise();
-  }
-#endif
-
-  u64 boot_time_adjustment = get_boot_time();
-  /* insert time onto the bpf program */
-  bpf_src = std::regex_replace(
-    bpf_src, std::regex("BOOT_TIME_ADJUSTMENT"),
-    fmt::format("{}uLL", boot_time_adjustment)
-  );
-  bpf_src = std::regex_replace(
-    bpf_src, std::regex("FILTER_NS"),
-    fmt::format("{}", args::get(filter_ns))
-  );
-  bpf_src = std::regex_replace(
-    bpf_src, std::regex("MAX_PID"),
-    *read_file_as_string(MAX_PID_PROC_PATH).try_raise()
-  );
-  bpf_src = std::regex_replace(
-    bpf_src, std::regex("CPU_MEM_IO_ENABLED"),
-    std::string(1, "01"[try_get_env_value<bool>(ENABLE_EBPF_CPU_MEM_IO_VAR)])
-  );
-  bpf_src = std::regex_replace(
-    bpf_src, std::regex("REPORT_DEBUG_EVENTS_PLACEHOLDER"),
-    std::string(1, "01"[*report_bpf_debug_events])
-  );
-
-  if (std::string const out{try_get_env_var(FLOWMILL_EXPORT_BPF_SRC_FILE_VAR)}; !out.empty()) {
-    if (auto const error = write_file(out.c_str(), bpf_src)) {
-      LOG::error("ERROR: unable to write BPF source to '{}': {}", out, error);
-    }
-  }
-
-  uv_timer_t refill_log_rate_limit_timer;
-  if (!disable_log_rate_limit) {
-    LOG::enable_rate_limit(5000);
-    res = uv_timer_init(&loop, &refill_log_rate_limit_timer);
-    if (res != 0) {
-      throw std::runtime_error("Cannot init rate limit timer.");
-    }
-
-    res = uv_timer_start(&refill_log_rate_limit_timer, refill_log_rate_limit_cb,
-                         /*1s*/ 1000, /*1s*/ 1000);
-    if (res != 0) {
-      throw std::runtime_error("Cannot start rate limit timer.");
-    }
-  }
-
-  /* initialize curl engine */
-  auto curl_engine = CurlEngine::create(&loop);
-
-
-  auto maybe_proxy_config = config::HttpProxyConfig::read_from_env();
-  auto proxy_config = maybe_proxy_config ? &*maybe_proxy_config : nullptr;
-  AuthzFetcher authz_fetcher{*curl_engine, *authz_server, agent_key, agent_id, proxy_config};
-
-  auto intake_config = intake_config_handler.read_config(authz_fetcher.token()->intake());
-
-  if (disable_intake_tls.given()) {
-    intake_config.disable_tls(*disable_intake_tls);
-  }
-
-  // Initialize our kernel telemetry collector
-  KernelCollector kernel_collector{
-    bpf_src, intake_config, boot_time_adjustment,
-    aws_metadata.try_value(), gcp_metadata.try_value(),
-    configuration_data.labels(), loop, *curl_engine,
-    authz_fetcher,
-    enable_http_metrics,
-    enable_userland_tcp,
-    CgroupHandler::CgroupSettings{
-      .force_docker_metadata = *force_docker_metadata,
-      .dump_docker_metadata = *dump_docker_metadata,
-    },
-    nullptr,
-    bpf_dump_file.Get(),
-    HostInfo{
-      .os = OperatingSystem::Linux,
+  HostInfo host_info{
+    .os = OperatingSystem::Linux,
       .os_flavor = integer_value(*host_distro),
       .os_version = gcp_metadata ? gcp_metadata->image() : "unknown",
       .kernel_headers_source = *kernel_headers_source,
       .kernel_version = unamebuf.release,
-      .hostname = hostname
-    }, *entrypoint_error
-  };
+      .hostname = hostname};
 
-  authz_fetcher.auto_refresh(
+  try {
+    /* mount debugfs if it is not mounted */
+    mount_debugfs_if_required();
 
-    loop,
-    std::bind(&KernelCollector::update_authz_token, &kernel_collector, std::placeholders::_1)
-  );
+    /* Read our BPF program*/
+    /* resolve includes */
+    std::string bpf_src((char *)agent_bpf_c, agent_bpf_c_len);
+#ifdef CONFIGURABLE_BPF
+    if (bpf_file.Matched()) {
+      bpf_src = *read_file_as_string(bpf_file.Get().c_str()).try_raise();
+    }
+#endif
 
-  signal_manager.handle_signals(
-    {SIGINT, SIGTERM},
-    std::bind(&KernelCollector::on_close, &kernel_collector)
-  );
+    u64 boot_time_adjustment = get_boot_time();
+    /* insert time onto the bpf program */
+    bpf_src = std::regex_replace(
+      bpf_src, std::regex("BOOT_TIME_ADJUSTMENT"),
+      fmt::format("{}uLL", boot_time_adjustment)
+    );
+    bpf_src = std::regex_replace(
+      bpf_src, std::regex("FILTER_NS"),
+      fmt::format("{}", args::get(filter_ns))
+    );
+    bpf_src = std::regex_replace(
+      bpf_src, std::regex("MAX_PID"),
+      *read_file_as_string(MAX_PID_PROC_PATH).try_raise()
+    );
+    bpf_src = std::regex_replace(
+      bpf_src, std::regex("CPU_MEM_IO_ENABLED"),
+      std::string(1, "01"[try_get_env_value<bool>(ENABLE_EBPF_CPU_MEM_IO_VAR)])
+    );
+    bpf_src = std::regex_replace(
+      bpf_src, std::regex("REPORT_DEBUG_EVENTS_PLACEHOLDER"),
+      std::string(1, "01"[*report_bpf_debug_events])
+    );
 
-  LOG::debug("starting event loop...");
-  uv_run(&loop, UV_RUN_DEFAULT);
+    if (std::string const out{try_get_env_var(FLOWMILL_EXPORT_BPF_SRC_FILE_VAR)}; !out.empty()) {
+      if (auto const error = write_file(out.c_str(), bpf_src)) {
+        LOG::error("ERROR: unable to write BPF source to '{}': {}", out, error);
+      }
+    }
+
+    uv_timer_t refill_log_rate_limit_timer;
+    if (!disable_log_rate_limit) {
+      LOG::enable_rate_limit(5000);
+      res = uv_timer_init(&loop, &refill_log_rate_limit_timer);
+      if (res != 0) {
+        throw std::runtime_error("Cannot init rate limit timer.");
+      }
+
+      res = uv_timer_start(&refill_log_rate_limit_timer, refill_log_rate_limit_cb,
+                           /*1s*/ 1000, /*1s*/ 1000);
+      if (res != 0) {
+        throw std::runtime_error("Cannot start rate limit timer.");
+      }
+    }
+
+    /* initialize curl engine */
+    auto curl_engine = CurlEngine::create(&loop);
+
+
+    auto maybe_proxy_config = config::HttpProxyConfig::read_from_env();
+    auto proxy_config = maybe_proxy_config ? &*maybe_proxy_config : nullptr;
+    AuthzFetcher authz_fetcher{*curl_engine, *authz_server, agent_key, agent_id, proxy_config};
+
+    auto intake_config = intake_config_handler.read_config(authz_fetcher.token()->intake());
+
+    if (disable_intake_tls.given()) {
+      intake_config.disable_tls(*disable_intake_tls);
+    }
+
+    // Initialize our kernel telemetry collector
+    KernelCollector kernel_collector{
+      bpf_src, intake_config, boot_time_adjustment,
+        aws_metadata.try_value(), gcp_metadata.try_value(),
+        configuration_data.labels(), loop, *curl_engine,
+        authz_fetcher,
+        enable_http_metrics,
+        enable_userland_tcp,
+        CgroupHandler::CgroupSettings{
+        .force_docker_metadata = *force_docker_metadata,
+          .dump_docker_metadata = *dump_docker_metadata,
+          },
+        nullptr,
+          bpf_dump_file.Get(),
+          host_info,
+          *entrypoint_error
+                 };
+
+    authz_fetcher.auto_refresh(
+      loop,
+      std::bind(&KernelCollector::update_authz_token, &kernel_collector, std::placeholders::_1)
+    );
+
+    signal_manager.handle_signals(
+      {SIGINT, SIGTERM},
+      std::bind(&KernelCollector::on_close, &kernel_collector)
+    );
+
+    LOG::debug("starting event loop...");
+    uv_run(&loop, UV_RUN_DEFAULT);
+  } catch (std::system_error &e) {
+    if (e.code().value() == EPERM) {
+      print_troubleshooting_message_and_exit(host_info, TroubleshootItem::operation_not_permitted, e);
+      return 1;
+    }
+    print_troubleshooting_message_and_exit(host_info, TroubleshootItem::unexpected_exception, e);
+    return 1;
+  } catch (std::exception &e) {
+    print_troubleshooting_message_and_exit(host_info, TroubleshootItem::unexpected_exception, e);
+    return 1;
+  }
 }

--- a/collector/kernel/main.cc
+++ b/collector/kernel/main.cc
@@ -565,7 +565,7 @@ int main(int argc, char *argv[]) {
   }
 
   HostInfo host_info{
-    .os = OperatingSystem::Linux,
+      .os = OperatingSystem::Linux,
       .os_flavor = integer_value(*host_distro),
       .os_version = gcp_metadata ? gcp_metadata->image() : "unknown",
       .kernel_headers_source = *kernel_headers_source,
@@ -645,21 +645,25 @@ int main(int argc, char *argv[]) {
 
     // Initialize our kernel telemetry collector
     KernelCollector kernel_collector{
-      bpf_src, intake_config, boot_time_adjustment,
-        aws_metadata.try_value(), gcp_metadata.try_value(),
-        configuration_data.labels(), loop, *curl_engine,
+        bpf_src,
+        intake_config,
+        boot_time_adjustment,
+        aws_metadata.try_value(),
+        gcp_metadata.try_value(),
+        configuration_data.labels(),
+        loop,
+        *curl_engine,
         authz_fetcher,
         enable_http_metrics,
         enable_userland_tcp,
         CgroupHandler::CgroupSettings{
-        .force_docker_metadata = *force_docker_metadata,
-          .dump_docker_metadata = *dump_docker_metadata,
-          },
+            .force_docker_metadata = *force_docker_metadata,
+            .dump_docker_metadata = *dump_docker_metadata,
+        },
         nullptr,
-          bpf_dump_file.Get(),
-          host_info,
-          *entrypoint_error
-                 };
+        bpf_dump_file.Get(),
+        host_info,
+        *entrypoint_error};
 
     authz_fetcher.auto_refresh(
       loop,

--- a/collector/kernel/troubleshoot_item.h
+++ b/collector/kernel/troubleshoot_item.h
@@ -20,8 +20,10 @@
 
 #define ENUM_NAME TroubleshootItem
 #define ENUM_TYPE std::uint8_t
-#define ENUM_ELEMENTS(X)                                                       \
-  X(none, 0)                                                                   \
-  X(bpf_compilation_failed, 1)
+#define ENUM_ELEMENTS(X)                                                \
+  X(none, 0)                                                            \
+  X(bpf_compilation_failed, 1)                                          \
+  X(operation_not_permitted, 2)                                         \
+  X(unexpected_exception, 3)
 #define ENUM_DEFAULT none
 #include <util/enum_operators.inl>

--- a/collector/kernel/troubleshoot_item.h
+++ b/collector/kernel/troubleshoot_item.h
@@ -23,7 +23,8 @@
 #define ENUM_ELEMENTS(X)                                                \
   X(none, 0)                                                            \
   X(bpf_compilation_failed, 1)                                          \
-  X(operation_not_permitted, 2)                                         \
-  X(unexpected_exception, 3)
+  X(bpf_load_probes_failed, 2)                                          \
+  X(operation_not_permitted, 3)                                         \
+  X(unexpected_exception, 4)
 #define ENUM_DEFAULT none
 #include <util/enum_operators.inl>

--- a/collector/kernel/troubleshooting.cc
+++ b/collector/kernel/troubleshooting.cc
@@ -199,6 +199,18 @@ the problem.
       break;
     }
 
+  case TroubleshootItem::bpf_load_probes_failed: {
+      std::cout << fmt::format(R"TROUBLESHOOTING(
+Failed to load eBPF probes for the Linux distro '{}' running kernel version {}.
+
+{}
+
+Please reach out to Flowmill and include this log in its entirety so we can diagnose and fix
+the problem.
+)TROUBLESHOOTING", static_cast<LinuxDistro>(info.os_flavor), info.kernel_version, item_fmt);
+      break;
+    }
+
     case TroubleshootItem::operation_not_permitted: {
       exit_sleep_sec = EXIT_SLEEP_FOREVER;
       std::cout << fmt::format(R"TROUBLESHOOTING(

--- a/collector/kernel/troubleshooting.cc
+++ b/collector/kernel/troubleshooting.cc
@@ -27,7 +27,8 @@
 
 #include <cstdlib>
 
-static constexpr auto EXIT_GRACE_PERIOD = 60s;
+static constexpr auto EXIT_SLEEP_GRACE_PERIOD_DEFAULT = 60s;
+static constexpr auto EXIT_SLEEP_FOREVER = std::chrono::seconds::max();
 
 constexpr std::string_view KERNEL_HEADERS_MANUAL_INSTALL_INSTRUCTIONS = R"INSTRUCTIONS(
 In the meantime, please install kernel headers manually on each host before running
@@ -44,15 +45,19 @@ To manually install kernel headers, follow the instructions below:
       sudo yum install -y "kernel-devel-`uname -r`"
 )INSTRUCTIONS";
 
-void close_agent(int exit_code) {
-  std::this_thread::sleep_for(EXIT_GRACE_PERIOD);
+void close_agent(int exit_code, std::function<void()> flush_and_close, std::chrono::seconds exit_sleep_sec) {
+  if (flush_and_close) {
+    flush_and_close();
+  }
+  std::this_thread::sleep_for(exit_sleep_sec);
   exit(exit_code);
 }
 
 void print_troubleshooting_message_and_exit(
-  logging::Logger &log,
   HostInfo const &info,
-  EntrypointError error
+  EntrypointError error,
+  logging::Logger &log,
+  std::function<void()> flush_and_close
 ) {
   if (error == EntrypointError::none) { return; }
 
@@ -145,38 +150,81 @@ the problem.
 )TROUBLESHOOTING";
       break;
     }
-
-    std::cout << std::endl << FLOWMILL_CONTACT_INFO_MESSAGE << std::endl;
-    std::cout.flush();
   }
 
-  close_agent(-1);
+  std::cout << std::endl << FLOWMILL_CONTACT_INFO_MESSAGE << std::endl;
+  std::cout.flush();
+
+  if (flush_and_close) {
+    flush_and_close();
+  }
+  close_agent(-1, flush_and_close, EXIT_SLEEP_GRACE_PERIOD_DEFAULT);
 }
 
 void print_troubleshooting_message_and_exit(
-  logging::Logger &log,
   HostInfo const &info,
   TroubleshootItem item,
-  std::exception const &e
+  std::exception const &e,
+  std::optional<std::reference_wrapper<logging::Logger>> log,
+  std::function<void()> flush_and_close
 ) {
   if (item == TroubleshootItem::none) { return; }
 
-  log.error(
-    "troubleshoot item {} (os={},flavor={},headers_src={},kernel={}): {}",
-    item, info.os, info.os_flavor, info.kernel_headers_source, info.kernel_version, e
+  auto const item_fmt = fmt::format(
+      "troubleshoot item {} (os={},flavor={},headers_src={},kernel={}): {}",
+      item, info.os, static_cast<LinuxDistro>(info.os_flavor),
+      info.kernel_headers_source, info.kernel_version, e
   );
 
+  if (log) {
+    log->get().error(item_fmt);
+  } else {
+    LOG::error(item_fmt);
+  }
+
+  auto exit_sleep_sec = EXIT_SLEEP_GRACE_PERIOD_DEFAULT;
   switch (item) {
     case TroubleshootItem::bpf_compilation_failed: {
       std::cout << fmt::format(R"TROUBLESHOOTING(
 Failed to compile eBPF code for the Linux distro '{}' running kernel version {}.
 
+{}
+
 This usually means that kernel headers weren't installed correctly.
 
 Please reach out to Flowmill and include this log in its entirety so we can diagnose and fix
 the problem.
-)TROUBLESHOOTING", static_cast<LinuxDistro>(info.os_flavor), info.kernel_version)
-        << std::endl << KERNEL_HEADERS_MANUAL_INSTALL_INSTRUCTIONS;
+)TROUBLESHOOTING", static_cast<LinuxDistro>(info.os_flavor), info.kernel_version, item_fmt)
+                << std::endl << KERNEL_HEADERS_MANUAL_INSTALL_INSTRUCTIONS;
+      break;
+    }
+
+    case TroubleshootItem::operation_not_permitted: {
+      exit_sleep_sec = EXIT_SLEEP_FOREVER;
+      std::cout << fmt::format(R"TROUBLESHOOTING(
+Insufficient permissions to perform a priviliged operation.
+Priviliged operations include mounting debugfs, loading eBPF code and probes, etc.
+Make sure to run as privileged user, and/or with --privileged flag or equivalant.
+
+{}
+
+Blocking to avoid failure retry loop.
+
+Please reach out to Flowmill and include this log in its entirety so we can diagnose and fix
+the problem.
+)TROUBLESHOOTING", item_fmt);
+      break;
+    }
+
+    case TroubleshootItem::unexpected_exception: {
+      std::cout << fmt::format(R"TROUBLESHOOTING(
+Unexpected exception.
+
+{}
+
+Please reach out to Flowmill and include this log in its entirety so we can diagnose and fix
+the problem.
+)TROUBLESHOOTING", item_fmt);
       break;
     }
 
@@ -189,10 +237,10 @@ the problem.
 )TROUBLESHOOTING";
       break;
     }
-
-    std::cout << std::endl << FLOWMILL_CONTACT_INFO_MESSAGE << std::endl;
-    std::cout.flush();
   }
 
-  close_agent(-1);
+  std::cout << std::endl << FLOWMILL_CONTACT_INFO_MESSAGE << std::endl;
+  std::cout.flush();
+
+  close_agent(-1, flush_and_close, exit_sleep_sec);
 }

--- a/collector/kernel/troubleshooting.h
+++ b/collector/kernel/troubleshooting.h
@@ -40,16 +40,18 @@ you're encountering so we can better support you.
  *
  * In case the error is unrecoverable, calls `exit()` and doesn't return.
  */
-void print_troubleshooting_message_and_exit(logging::Logger &log,
-                                            HostInfo const &info,
-                                            EntrypointError error);
+void print_troubleshooting_message_and_exit(HostInfo const &info,
+                                            EntrypointError error,
+                                            logging::Logger &log,
+                                            std::function<void()> flush_and_close);
 
 /**
  * Prints a troubleshooting message for the given item.
  *
  * In case the item is unrecoverable, calls `exit()` and doesn't return.
  */
-void print_troubleshooting_message_and_exit(logging::Logger &log,
-                                            HostInfo const &info,
+void print_troubleshooting_message_and_exit(HostInfo const &info,
                                             TroubleshootItem item,
-                                            std::exception const &e);
+                                            std::exception const &e,
+                                            std::optional<std::reference_wrapper<logging::Logger>> log = std::nullopt,
+                                            std::function<void()> flush_and_close = nullptr);

--- a/util/logger.h
+++ b/util/logger.h
@@ -32,6 +32,9 @@ public:
     writer_(writer)
   {}
 
+  Logger (const Logger&) = delete;
+  Logger& operator= (const Logger&) = delete;
+
   template <typename Format, typename... Args>
   inline void info(Format &&format, Args &&... args) {
     LOG::info(


### PR DESCRIPTION
In order to be able to run the agent anywhere, including where there are insufficient permissions to load BPF code and perform other privileged operations, fail and block forever to avoid failure retry loop if there are insufficient permissions.

An example of what is logged when attempting to load BPF code fails due to insufficient permissions:

launching kernel collector...
< snip >
could not open bpf map: data_channel, error: Operation not permitted
2021-07-19 21:08:14.881823+00:00 error [p:015330 t:015330] Cannot initialize BPF program, res=-1

Insufficient permissions to perform a priviliged operation.
Priviliged operations include mounting debugfs, loading eBPF code and probes, etc.
Make sure to run as privileged user, and/or with --privileged flag or equivalant.

troubleshoot item operation_not_permitted (os=Linux,flavor=debian,headers_src=pre_installed,kernel=4.9.0-16-amd64): ProbeHandler couldn't load BPFModule: Operation not permitted

Blocking to avoid failure retry loop.

Please reach out to Flowmill and include this log in its entirety so we can diagnose and fix
the problem.
2021-07-19 21:08:14.887814+00:00 error [p:015330 t:015330] BPFHandler threw exception when initializing BPF or loading probes, closing connection: ProbeHandler couldn't load BPFModule: Operation not permitted


To reach Flowmill customer support, please choose one of the contact methods below:

- the shared Slack channel that has been setup between your company and `flowmill.slack.com`;

- email `support@flowmill.com`, prefixing the subject with "Kernel Collector Issue: ".

If possible, please include these logs in the message, along with a description of the problem
you're encountering so we can better support you.

2021-07-19 21:08:14.887843+00:00 error [p:015330 t:015330] troubleshoot item operation_not_permitted (os=Linux,flavor=debian,headers_src=pre_installed,kernel=4.9.0-16-amd64): ProbeHandler couldn't load BPFModule: Operation not permitted



And on the Flowmill server:
2021-07-19 21:08:09.878867+00:00 info [p:000001 t:000021] (0) kernel collector at 'stretch' successfully authenticated
2021-07-19 21:08:14.888461+00:00 error [p:000001 t:000019] client log from kernel collector 0.9.4012 at 'stretch': BPFHandler threw exception when initializing BPF or loading probes, closing connection: ProbeHandler couldn't load BPFModule: Operation not permitted
2021-07-19 21:08:14.888491+00:00 error [p:000001 t:000019] client log from kernel collector 0.9.4012 at 'stretch': troubleshoot item operation_not_permitted (os=Linux,flavor=debian,headers_src=pre_installed,kernel=4.9.0-16-amd64): ProbeHandler couldn't load BPFModule: Operation not permitted
2021-07-19 21:08:14.888509+00:00 info [p:000001 t:000019] Connection closed from kernel collector at 'stretch'


Question: should the "Flowmill customer support" contact information in the above logs be updated?